### PR TITLE
Plank - Add theme-based separator padding

### DIFF
--- a/data/themes/Default/dock.theme
+++ b/data/themes/Default/dock.theme
@@ -23,6 +23,8 @@ TopPadding=-11
 BottomPadding=2.5
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2.5
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
 IndicatorColor=255;;255;;255;;255
 #The size of item indicators, in tenths of a percent of IconSize.

--- a/data/themes/Matte-Light/dock.theme
+++ b/data/themes/Matte-Light/dock.theme
@@ -27,6 +27,8 @@ TopPadding=2
 BottomPadding=2
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
 IndicatorColor=255;;255;;255;;255
 #The size of item indicators, in tenths of a percent of IconSize.

--- a/data/themes/Matte/dock.theme
+++ b/data/themes/Matte/dock.theme
@@ -27,6 +27,8 @@ TopPadding=2
 BottomPadding=2
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
 IndicatorColor=255;;255;;255;;255
 #The size of item indicators, in tenths of a percent of IconSize.

--- a/data/themes/Minimal-Light/dock.theme
+++ b/data/themes/Minimal-Light/dock.theme
@@ -25,8 +25,10 @@ TopPadding=2
 BottomPadding=2.4
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
-IndicatorColor=200;;200;;200;;255
+IndicatorColor=75;;75;;75;;255
 #The size of item indicators, in tenths of a percent of IconSize.
 IndicatorSize=1
 #The style of item indicators, styles: circle-glow, circle-color-glow, circle, underline.

--- a/data/themes/Minimal/dock.theme
+++ b/data/themes/Minimal/dock.theme
@@ -25,6 +25,8 @@ TopPadding=2
 BottomPadding=2.4
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
 IndicatorColor=128;;128;;128;;255
 #The size of item indicators, in tenths of a percent of IconSize.

--- a/data/themes/Transparent/dock.theme
+++ b/data/themes/Transparent/dock.theme
@@ -23,6 +23,8 @@ TopPadding=-12
 BottomPadding=2
 #The padding between items on the dock, in tenths of a percent of IconSize.
 ItemPadding=2.5
+#The padding before and after a separator, in tenths of a percent of IconSize.
+SeparatorPadding=-2
 #The color (RGBA) of the indicator.
 IndicatorColor=255;;255;;255;;255
 #The size of item indicators, in tenths of a percent of IconSize.

--- a/lib/Drawing/DockTheme.vala
+++ b/lib/Drawing/DockTheme.vala
@@ -113,6 +113,9 @@ namespace Plank {
     [Description (nick = "active-item-color", blurb = "The color (RGBA) of the active item background.")]
     public Color ActiveItemColor { get; set; }
 
+    [Description (nick = "separator-padding", blurb = "The padding before and after a separator, in tenths of a percent of IconSize.")]
+    public double SeparatorPadding { get; set; }
+
     public DockTheme (string name) {
       base.with_name (name);
     }
@@ -128,6 +131,7 @@ namespace Plank {
       TopPadding = -11.0;
       BottomPadding = 2.5;
       ItemPadding = 2.5;
+      SeparatorPadding = -2;
       IndicatorColor = { 1.0, 1.0, 1.0, 1.0 };
       IndicatorSize = 5.0;
       IndicatorStyle = IndicatorStyleType.LEGACY;
@@ -816,6 +820,9 @@ namespace Plank {
       case "ActiveStyle":
         if (ActiveItemStyle < 0 || ActiveItemStyle > 2)
           ActiveItemStyle = ActiveItemStyleType.LEGACY;
+        break;
+
+      case "SeparatorPadding":
         break;
       }
     }


### PR DESCRIPTION
Fix https://github.com/zquestz/plank-reloaded/issues/66
Add theme-based separator padding :
--> Users can now specify the amount of space between the icon and the separator.