### PR TITLE
Debian CONTROL: add conflicts with plank

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -5,6 +5,7 @@ Section: x11
 Maintainer: Josh Ellithorpe <quest@mac.com>
 Architecture: amd64
 Depends: bamfdaemon, libgee-0.8-2, libgnome-menu-3-0, libwnck-3-0, libc6
+Conflicts: plank
 Homepage: https://github.com/zquestz/plank-reloaded
 Description: Elegant and simple dock.
  Plank Reloaded is a fork of the original Plank project, providing a simple dock


### PR DESCRIPTION
plank-reloaded and plank are using the same binary name and paths so this makes it so one cannot install plank and plank-reloaded at the same time.