### PR TITLE
Update README.md to consistently use apt for Debian and derivates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ You can download the `plank-reloaded.deb` package from the [Releases](https://gi
 
 ```bash
 # Completely uninstall plank
-sudo apt-get remove plank libplank-common libplank1
+sudo apt remove plank libplank-common libplank1
 
 # Install required dependencies
-sudo apt-get install git meson gettext valac libgnome-menu-3.0 libgnome-menu-3-dev libxml2-utils gtk+-3.0 gee-0.8 libbamf3-dev libwnck-3.0 libwnck-3-dev bamfdaemon
+sudo apt install git meson gettext valac libgnome-menu-3.0 libgnome-menu-3-dev libxml2-utils gtk+-3.0 gee-0.8 libbamf3-dev libwnck-3.0 libwnck-3-dev bamfdaemon
 
 # Clone the repository
 git clone https://github.com/zquestz/plank-reloaded.git
@@ -148,10 +148,10 @@ You can download the `plank-reloaded-debian.deb` package from the [Releases](htt
 
 ```bash
 # Completely uninstall plank
-sudo apt-get remove plank libplank-common libplank1
+sudo apt remove plank libplank-common libplank1
 
 # Install required dependencies
-sudo apt-get install git meson gettext valac libgnome-menu-3.0 libgnome-menu-3-dev libxml2-utils gtk+-3.0 gee-0.8 libbamf3-dev libwnck-3.0 libwnck-3-dev bamfdaemon
+sudo apt install git meson gettext valac libgnome-menu-3.0 libgnome-menu-3-dev libxml2-utils gtk+-3.0 gee-0.8 libbamf3-dev libwnck-3.0 libwnck-3-dev bamfdaemon
 
 # Clone the repository
 git clone https://github.com/zquestz/plank-reloaded.git


### PR DESCRIPTION
Always use apt for package commands for Debian and derivatives for a more pleasant experience and a progress display.