### PR TITLE
Add option to bring windows to the current workspace on activation

### DIFF
--- a/data/net.launchpad.plank.gschema.xml.in
+++ b/data/net.launchpad.plank.gschema.xml.in
@@ -31,6 +31,12 @@
 			<summary>Array of names of active/enabled docks</summary>
 			<description>Contains the names of docks which are created and loaded on start up</description>
 		</key>
+
+		<key name="bring-window-to-current-workspace" type="b">
+			<default>false</default>
+			<summary>Bring windows to the current workspace when activated</summary>
+			<description>If true, activating a window located on another workspace moves it to the current workspace instead of switching to the window's workspace.</description>
+		</key>
 	</schema>
 
 	<schema id="net.launchpad.plank.dock.settings" gettext-domain="@GETTEXT_PACKAGE@">

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -763,6 +763,38 @@ along with plank.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="top_attach">7</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="l_bring_to_workspace">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property
+                  name="label"
+                  translatable="yes"
+                >Bring to Workspace:</property>
+                <property name="justify">right</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="sw_bring_to_workspace">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property
+                  name="tooltip_text"
+                  translatable="yes"
+                >When activating a window located on another workspace, move it to the current workspace instead of switching to the window's workspace.</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="name">grid_behaviour</property>

--- a/lib/Services/WindowControl.vala
+++ b/lib/Services/WindowControl.vala
@@ -43,6 +43,9 @@ namespace Plank {
     static uint delayed_focus_timer_id = 0U;
     static ulong delayed_focus_xid = 0UL;
 
+    static GLib.Settings? global_settings = null;
+    static bool bring_window_to_current_workspace = false;
+
     // Action type for pending operations
     enum PendingActionType {
       MINIMIZE,
@@ -186,6 +189,12 @@ namespace Plank {
 
     public static void initialize () {
       Wnck.set_client_type (Wnck.ClientType.PAGER);
+
+      global_settings = create_settings ("net.launchpad.plank");
+      bring_window_to_current_workspace = global_settings.get_boolean ("bring-window-to-current-workspace");
+      global_settings.changed["bring-window-to-current-workspace"].connect (() => {
+        bring_window_to_current_workspace = global_settings.get_boolean ("bring-window-to-current-workspace");
+      });
 
       unowned Wnck.Screen screen = Wnck.Screen.get_default ();
 
@@ -810,9 +819,14 @@ namespace Plank {
 
     static void center_and_focus_window (Wnck.Window w, uint32 event_time) {
       unowned Wnck.Workspace? workspace = w.get_workspace ();
+      unowned Wnck.Workspace? active_workspace = w.get_screen ().get_active_workspace ();
 
-      if (!w.is_pinned () && !w.is_sticky () && workspace != null && workspace != w.get_screen ().get_active_workspace ())
-        workspace.activate (event_time);
+      if (!w.is_pinned () && !w.is_sticky () && workspace != null && active_workspace != null && workspace != active_workspace) {
+        if (bring_window_to_current_workspace)
+          w.move_to_workspace (active_workspace);
+        else
+          workspace.activate (event_time);
+      }
 
       if (w.is_minimized ())
         w.unminimize (event_time);

--- a/lib/Widgets/PreferencesWindow.vala
+++ b/lib/Widgets/PreferencesWindow.vala
@@ -26,6 +26,7 @@ namespace Plank {
     public DockController controller { get; construct set; }
 
     DockPreferences prefs;
+    GLib.Settings global_settings;
 
     bool refreshing_display_plugs = false;
 
@@ -90,6 +91,8 @@ namespace Plank {
     unowned Gtk.Switch sw_pressure_reveal;
     [GtkChild]
     unowned Gtk.Switch sw_zoom_enabled;
+    [GtkChild]
+    unowned Gtk.Switch sw_bring_to_workspace;
 
     [GtkChild]
     unowned Gtk.IconView view_docklets;
@@ -103,6 +106,10 @@ namespace Plank {
       var title = _("Preferences");
 
       prefs = controller.prefs;
+
+      global_settings = create_settings ("net.launchpad.plank");
+      global_settings.bind ("bring-window-to-current-workspace", sw_bring_to_workspace,
+                            "active", SettingsBindFlags.DEFAULT);
 
       init_dock_tab ();
       init_docklets_tab ();


### PR DESCRIPTION
## Summary

Adds an opt-in setting so that activating (clicking the dock icon of) a window located on another workspace **brings the window to your current workspace** instead of switching the active workspace to the window's one. Disabled by default, so existing behavior is unchanged.

## Motivation

In a dock-driven workflow the expectation is "give me that window here", not "send me over to wherever that window is". The current behavior is especially disruptive with minimized windows: clicking their icon yanks you to a different workspace and away from your current context.

This is also a long-standing pain point on Xfce/xfwm4: xfwm4 has a `bring window on current workspace` activation option, but it is ignored for activation requests carrying the pager source indication (which docks send), so users cannot get "bring" behavior from the WM side. Handling it in Plank lets those users opt in regardless of the WM.

## Behavior

New setting `bring-window-to-current-workspace` (boolean, default `false`), exposed as a **"Bring to Workspace"** switch on the **Behaviour** tab of the preferences dialog:

- `false` (default): unchanged. Activating a window on another workspace switches the desktop to that window's workspace.
- `true`: the window is moved to the currently active workspace and activated there; you stay where you are.

Pinned and sticky windows are left untouched (same guard as before). On viewport-based (virtual) desktops `get_workspace()` returns the single shared workspace, so the condition does not fire and behavior is unchanged there.

## Implementation

- `data/net.launchpad.plank.gschema.xml.in`: new key in the `net.launchpad.plank` schema.
- `lib/Services/WindowControl.vala`: the key is read in `initialize()` and kept in sync via the GSettings `changed` signal (runtime-toggleable). In `center_and_focus_window`, when the key is set, `workspace.activate()` is replaced with `w.move_to_workspace(active_workspace)`.
- `data/ui/preferences.ui` + `lib/Widgets/PreferencesWindow.vala`: a switch on the Behaviour tab, two-way bound to the key via `GLib.Settings.bind()`.

```diff
-      if (!w.is_pinned () && !w.is_sticky () && workspace != null && workspace != w.get_screen ().get_active_workspace ())
-        workspace.activate (event_time);
+      if (!w.is_pinned () && !w.is_sticky () && workspace != null && active_workspace != null && workspace != active_workspace) {
+        if (bring_window_to_current_workspace)
+          w.move_to_workspace (active_workspace);
+        else
+          workspace.activate (event_time);
+      }
```

The key is global rather than per-dock because window activation is handled by the shared static `WindowControl` service, and the behavior is a global user preference rather than something meaningful to vary per dock. The switch is therefore bound directly to the global schema instead of `DockPreferences`.

## Enabling

Via the preferences dialog (Behaviour tab -> "Bring to Workspace"), or:

```sh
gsettings set net.launchpad.plank bring-window-to-current-workspace true
```

## Testing

Built with meson/valac on Debian 13 and tested live under Xfce 4 / xfwm4:

- Key `false`: activating a window on another workspace switches the desktop (unchanged).
- Key `true`: the window comes to the current workspace instead; toggling the key (dialog switch or gsettings) takes effect without restarting the dock.
- Pinned/sticky and same-workspace activations behave as before in both cases.
- Preferences dialog loads with no GtkBuilder warnings; the new switch appears on the Behaviour tab and reflects/updates the key.
